### PR TITLE
Account select

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,7 +1,6 @@
 ---
 cluster:
 - "owens"
-- "owens-slurm"
 form:
   - version
   - bc_account

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,9 +1,14 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
 ---
 cluster:
 - "owens"
 form:
   - version
-  - bc_account
+  - account
   - bc_num_hours
   - bc_num_slots
   - num_cores
@@ -25,9 +30,13 @@ attributes:
   bc_num_slots: "1"
   bc_vnc_resolution:
     required: true
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   node_type:
     widget: select
     label: "Node type"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,8 +1,6 @@
 <%-
   ppn = num_cores.blank? ? 28 : num_cores.to_i
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
-
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
   partition = []
 
   if node_type == 'hugemem'
@@ -12,19 +10,12 @@
   end
 
   slurm_args = partition + [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--licenses", "stata@osc" ]
-  torque_args = node_type == 'any' ? "#{nodes}:ppn=#{ppn}" : "#{nodes}:ppn=#{ppn}:#{node_type}"
 %>
 ---
 batch_connect:
   template: vnc
 script:
   native:
-  <%- if torque_cluster %>
-    resources:
-      nodes: "<%= torque_args %>"
-      software: "stata"
-  <%- else %>
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-  <%- end %>
   <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -15,6 +15,7 @@
 batch_connect:
   template: vnc
 script:
+  accounting_id: "<%= account %>"
   native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.

It also removes all the now vestigial torque items.